### PR TITLE
Change resource names

### DIFF
--- a/datastore/linstor_un/clone
+++ b/datastore/linstor_un/clone
@@ -88,7 +88,7 @@ SIZE="${XPATH_ELEMENTS[j++]}"
 
 SRC_DEV="$SRC"
 SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
-DST_RES="one-image-${ID}"
+DST_RES="one-${ID}"
 DST_DEV="/dev/drbd/by-res/${DST_RES}/0"
 DST="$DST_DEV"
 

--- a/datastore/linstor_un/cp
+++ b/datastore/linstor_un/cp
@@ -122,7 +122,7 @@ set_up_datastore "$BASE_PATH" "$RESTRICTED_DIRS" "$SAFE_DIRS"
 IMAGE_HASH=`generate_image_hash`
 TMP_DST="$STAGING_DIR/$IMAGE_HASH"
 
-DST_RES="one-image-${ID}"
+DST_RES="one-${ID}"
 DST_DEV="/dev/drbd/by-res/${DST_RES}/0"
 DST="$DST_DEV"
 

--- a/datastore/linstor_un/linstor_utils.sh
+++ b/datastore/linstor_un/linstor_utils.sh
@@ -182,7 +182,7 @@ function linstor_get_snaps_for_res {
     $LINSTOR -m --output-version v1 snapshot list | \
         $JQ -r ".[].snapshot_dfns[]? | \
         select(.rsc_name==\"${RES}\") | .snapshot_name" | \
-        $AWK -F- '$1 == "snapshot" && $2 ~ /^[0-9]+$/ {print $2}' | \
+        $AWK -F- '$1 == "snap" && $2 ~ /^[0-9]+$/ {print $2}' | \
         sort -${SORT_FLAGS} | \
         xargs
 }

--- a/datastore/linstor_un/mkfs
+++ b/datastore/linstor_un/mkfs
@@ -106,7 +106,7 @@ linstor_load_keys
 
 set_up_datastore "$BASE_PATH" "$RESTRICTED_DIRS" "$SAFE_DIRS"
 
-DST_RES="one-image-${ID}"
+DST_RES="one-${ID}"
 DST_DEV="/dev/drbd/by-res/${DST_RES}/0"
 DST="$DST_DEV"
 

--- a/datastore/linstor_un/snap_delete
+++ b/datastore/linstor_un/snap_delete
@@ -59,7 +59,7 @@ SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
 
 linstor_load_keys
 
-SNAPSHOT="snapshot-${SNAP_ID}"
+SNAPSHOT="snap-${SNAP_ID}"
 
 # Remove snapshot from monitoring
 linstor_exec_and_log \

--- a/datastore/linstor_un/snap_flatten
+++ b/datastore/linstor_un/snap_flatten
@@ -68,7 +68,7 @@ fi
 
 for MRG_SNAP_ID in $ALL_SNAP_IDS; do
 
-    SNAPSHOT="snapshot-${MRG_SNAP_ID}"
+    SNAPSHOT="snap-${MRG_SNAP_ID}"
 
     if [ "$SNAP_ID" = "$MRG_SNAP_ID" ]; then
         # Rollback snapshot 

--- a/datastore/linstor_un/snap_revert
+++ b/datastore/linstor_un/snap_revert
@@ -73,7 +73,7 @@ linstor_load_keys
 # Revert to last snapshot
 #-------------------------------------------------------------------------------
 
-SNAPSHOT="snapshot-${SNAP_ID}"
+SNAPSHOT="snap-${SNAP_ID}"
 
 if [ "$SNAP_ID" = "$LAST_SNAP_ID" ]; then
 

--- a/tm/linstor_un/clone
+++ b/tm/linstor_un/clone
@@ -50,6 +50,7 @@ source ${DRIVER_PATH}/../../datastore/linstor_un/linstor_utils.sh
 
 SRC_DEV=`arg_path $SRC`
 SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
+IMAGE_ID="$(echo "$SRC_RES" | $AWK -F- '{print $NF}')"
 
 DST_HOST=`arg_host $DST`
 DST_PATH=`arg_path $DST`
@@ -57,7 +58,7 @@ DST_DIR=`dirname $DST_PATH`
 DS_ID=$(echo $DST_DIR | $AWK -F/ '{print $(NF-1)}')
 
 DISK_ID=$(echo $DST | awk -F. '{print $NF}')
-DST_RES="one-vm-${VM_ID}-disk-${DISK_ID}"
+DST_RES="one-${IMAGE_ID}-${VM_ID}-${DISK_ID}"
 DST_DEV="/dev/drbd/by-res/${DST_RES}/0"
 
 #-------------------------------------------------------------------------------

--- a/tm/linstor_un/cpds
+++ b/tm/linstor_un/cpds
@@ -106,18 +106,21 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VM_ID| $XPATH \
-                    /VM/DEPLOY_ID \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE )
 
-DEPLOY_ID="${XPATH_ELEMENTS[j++]}"
 SRC_DEV="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
 
-if [ "$CLONE" = "NO" ]; then
-    SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
-else
-    SRC_RES="one-vm-${VM_ID}-disk-${DISK_ID}"
+SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
+
+if [ "$CLONE" != "NO" ]; then
+    if [ -n "$SRC_DEV" ]; then
+        IMAGE_ID="$(echo "$SRC_RES" | $AWK -F- '{print $NF}')"
+    else
+        IMAGE_ID=sys
+    fi
+    SRC_RES="one-${IMAGE_ID}-${VM_ID}-${DISK_ID}"
     SRC_DEV="/dev/drbd/by-res/${SRC_RES}/0"
 fi
 

--- a/tm/linstor_un/delete
+++ b/tm/linstor_un/delete
@@ -73,7 +73,7 @@ linstor_load_keys
 if [ `is_disk $DST_PATH` -eq 0 ]; then
     # Directory: delete checkpoint and directory
 
-    CHECKPOINT_RES="one-vm-${VM_ID}-checkpoint"
+    CHECKPOINT_RES="one-sys-${VM_ID}-checkpoint"
 
     # Check if vm have checkpoint resource
     $LINSTOR -m --output-version v1 resource-definition list | \
@@ -96,18 +96,31 @@ fi
 #-------------------------------------------------------------------------------
 
 DISK_ID=$(echo "$DST_PATH" | $AWK -F. '{print $NF}')
-DST_DEV="$DST_PATH"
-DST_RES="one-vm-${VM_ID}-disk-${DISK_ID}"
 
 unset i j XPATH_ELEMENTS
 
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VM_ID| $XPATH \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE)
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE )
 
 SRC_DEV="${XPATH_ELEMENTS[j++]}"
-SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
+CLONE="${XPATH_ELEMENTS[j++]}"
+
+if [ "$CLONE" = "YES" ]; then
+    exit 0
+fi
+
+if [ -n "$SRC_DEV" ]; then
+    SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
+    IMAGE_ID="$(echo "$SRC_RES" | $AWK -F- '{print $NF}')"
+else
+    IMAGE_ID=sys
+fi
+
+DST_DEV="$DST_PATH"
+DST_RES="one-${IMAGE_ID}-${VM_ID}-${DISK_ID}"
 
 #-------------------------------------------------------------------------------
 # Delete the device

--- a/tm/linstor_un/ln
+++ b/tm/linstor_un/ln
@@ -59,9 +59,11 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onedatastore show -x $DS_ID | $XPATH \
-                    /DATASTORE/TEMPLATE/LS_CONTROLLERS)
+                    /DATASTORE/TEMPLATE/LS_CONTROLLERS \
+                    /DATASTORE/TEMPLATE/DISKLESS_POOL)
 
 LS_CONTROLLERS="${XPATH_ELEMENTS[j++]}"
+DISKLESS_POOL="${XPATH_ELEMENTS[j++]:-DfltDisklessStorPool}"
 
 linstor_load_keys
 

--- a/tm/linstor_un/mkimage
+++ b/tm/linstor_un/mkimage
@@ -51,7 +51,7 @@ DST_HOST=`arg_host $DST`
 DST_DIR=`dirname $DST_PATH`
 
 DISK_ID=$(basename ${DST_PATH} | cut -d. -f2)
-DST_RES="one-vm-${VM_ID}-disk-${DISK_ID}"
+DST_RES="one-sys-${VM_ID}-${DISK_ID}"
 DST_DEV="/dev/drbd/by-res/${DST_RES}/0"
 
 #-------------------------------------------------------------------------------

--- a/tm/linstor_un/mv
+++ b/tm/linstor_un/mv
@@ -113,11 +113,15 @@ if [ `is_disk $SRC_PATH` -eq 1 ]; then
 
     SRC_DEV="${XPATH_ELEMENTS[j++]}"
     CLONE="${XPATH_ELEMENTS[j++]}"
+    SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
 
-    if [ "$CLONE" = "NO" ]; then
-        SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
-    else
-        SRC_RES="one-vm-${VMID}-disk-${DISK_ID}"
+    if [ "$CLONE" != "NO" ]; then
+        if [ -n "$SRC_DEV" ]; then
+            IMAGE_ID="$(echo "$SRC_RES" | $AWK -F- '{print $NF}')"
+        else
+            IMAGE_ID=sys
+        fi
+        SRC_RES="one-${IMAGE_ID}-${VM_ID}-${DISK_ID}"
         SRC_DEV="/dev/drbd/by-res/${SRC_RES}/0"
     fi
 

--- a/tm/linstor_un/resize
+++ b/tm/linstor_un/resize
@@ -50,7 +50,29 @@ SRC_PATH=`arg_path $SRC`
 
 DISK_ID=$(echo "$SRC_PATH" | $AWK -F. '{print $NF}')
 DS_ID=$(echo $SRC_PATH | $AWK -F/ '{print $(NF-2)}')
-SRC_RES="one-vm-${VM_ID}-disk-${DISK_ID}"
+
+unset i j XPATH_ELEMENTS
+
+while IFS= read -r -d '' element; do
+    XPATH_ELEMENTS[i++]="$element"
+done < <(onevm show -x $VM_ID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE )
+
+SRC_DEV="${XPATH_ELEMENTS[j++]}"
+CLONE="${XPATH_ELEMENTS[j++]}"
+
+SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
+
+if [ "$CLONE" != "NO" ]; then
+    if [ -n "$SRC_DEV" ]; then
+        IMAGE_ID="$(echo "$SRC_RES" | $AWK -F- '{print $NF}')"
+    else
+        IMAGE_ID=sys
+    fi
+    SRC_RES="one-${IMAGE_ID}-${VM_ID}-${DISK_ID}"
+    SRC_DEV="/dev/drbd/by-res/${SRC_RES}/0"
+fi
 
 XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
 

--- a/tm/linstor_un/snap_create
+++ b/tm/linstor_un/snap_create
@@ -75,10 +75,15 @@ done < <(onevm show -x $VM_ID| $XPATH \
 SRC_DEV="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
 
-if [ "$CLONE" = "NO" ]; then
-    SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
-else
-    SRC_RES="one-vm-${VM_ID}-disk-${DISK_ID}"
+SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
+
+if [ "$CLONE" != "NO" ]; then
+    if [ -n "$SRC_DEV" ]; then
+        IMAGE_ID="$(echo "$SRC_RES" | $AWK -F- '{print $NF}')"
+    else
+        IMAGE_ID=sys
+    fi
+    SRC_RES="one-${IMAGE_ID}-${VM_ID}-${DISK_ID}"
     SRC_DEV="/dev/drbd/by-res/${SRC_RES}/0"
 fi
 
@@ -86,7 +91,7 @@ fi
 # Create snapshot
 #-------------------------------------------------------------------------------
 
-SNAPSHOT="snapshot-${SNAP_ID}"
+SNAPSHOT="snap-${SNAP_ID}"
 
 # Create snapshot
 linstor_exec_and_log \

--- a/tm/linstor_un/snap_create_live
+++ b/tm/linstor_un/snap_create_live
@@ -78,10 +78,15 @@ DEPLOY_ID="${XPATH_ELEMENTS[j++]}"
 SRC_DEV="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
 
-if [ "$CLONE" = "NO" ]; then
-    SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
-else
-    SRC_RES="one-vm-${VM_ID}-disk-${DISK_ID}"
+SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
+
+if [ "$CLONE" != "NO" ]; then
+    if [ -n "$SRC_DEV" ]; then
+        IMAGE_ID="$(echo "$SRC_RES" | $AWK -F- '{print $NF}')"
+    else
+        IMAGE_ID=sys
+    fi
+    SRC_RES="one-${IMAGE_ID}-${VM_ID}-${DISK_ID}"
     SRC_DEV="/dev/drbd/by-res/${SRC_RES}/0"
 fi
 

--- a/tm/linstor_un/snap_delete
+++ b/tm/linstor_un/snap_delete
@@ -75,10 +75,15 @@ done < <(onevm show -x $VM_ID| $XPATH \
 SRC_DEV="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
 
-if [ "$CLONE" = "NO" ]; then
-    SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
-else
-    SRC_RES="one-vm-${VM_ID}-disk-${DISK_ID}"
+SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
+
+if [ "$CLONE" != "NO" ]; then
+    if [ -n "$SRC_DEV" ]; then
+        IMAGE_ID="$(echo "$SRC_RES" | $AWK -F- '{print $NF}')"
+    else
+        IMAGE_ID=sys
+    fi
+    SRC_RES="one-${IMAGE_ID}-${VM_ID}-${DISK_ID}"
     SRC_DEV="/dev/drbd/by-res/${SRC_RES}/0"
 fi
 
@@ -86,7 +91,7 @@ fi
 # Delete snapshot
 #-------------------------------------------------------------------------------
 
-SNAPSHOT="snapshot-${SNAP_ID}"
+SNAPSHOT="snap-${SNAP_ID}"
 
 # Remove snapshot from monitoring
 linstor_exec_and_log \

--- a/tm/linstor_un/snap_revert
+++ b/tm/linstor_un/snap_revert
@@ -82,10 +82,15 @@ SRC_DEV="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
 LAST_SNAP_ID="${XPATH_ELEMENTS[j++]}"
 
-if [ "$CLONE" = "NO" ]; then
-    SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
-else
-    SRC_RES="one-vm-${VM_ID}-disk-${DISK_ID}"
+SRC_RES="$(echo "$SRC_DEV" | $AWK -F/ '{print $(NF-1)}')"
+
+if [ "$CLONE" != "NO" ]; then
+    if [ -n "$SRC_DEV" ]; then
+        IMAGE_ID="$(echo "$SRC_RES" | $AWK -F- '{print $NF}')"
+    else
+        IMAGE_ID=sys
+    fi
+    SRC_RES="one-${IMAGE_ID}-${VM_ID}-${DISK_ID}"
     SRC_DEV="/dev/drbd/by-res/${SRC_RES}/0"
 fi
 
@@ -93,7 +98,7 @@ fi
 # Revert to last snapshot
 #-------------------------------------------------------------------------------
 
-SNAPSHOT="snapshot-${SNAP_ID}"
+SNAPSHOT="snap-${SNAP_ID}"
 
 if [ "$SNAP_ID" = "$LAST_SNAP_ID" ]; then
 

--- a/vmm/kvm/restore_linstor_un
+++ b/vmm/kvm/restore_linstor_un
@@ -44,7 +44,7 @@ TM_MAD="${XPATH_ELEMENTS[j++]}"
 LS_CONTROLLERS="${XPATH_ELEMENTS[j++]}"
 DISKLESS_POOL="${XPATH_ELEMENTS[j++]:-DfltDisklessStorPool}"
 
-SRC_RES="one-vm-${VM_ID}-checkpoint"
+SRC_RES="one-sys-${VM_ID}-checkpoint"
 SRC_DEV="/dev/drbd/by-res/${SRC_RES}/0"
 SRC_XML=${SRC_PATH}.xml
 DS_ID=$(echo $SRC_PATH | $AWK -F/ '{print $(NF-2)}')

--- a/vmm/kvm/save_linstor_un
+++ b/vmm/kvm/save_linstor_un
@@ -71,7 +71,7 @@ if [ -n "$CHECKPOINT_AUTO_PLACE" ]; then
     AUTO_PLACE="$CHECKPOINT_AUTO_PLACE"
 fi
 
-DST_RES="one-vm-${VM_ID}-checkpoint"
+DST_RES="one-sys-${VM_ID}-checkpoint"
 DST_DEV="/dev/drbd/by-res/${DST_RES}/0"
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This PR changes resource names:

images:
```diff
-one-image-${IMAGE_ID}
+one-${IMAGE_ID}
```

vms:
```diff
-one-vm-${VM_ID}-disk-${DISK_ID}
+one-${IMAGE_ID}-${VM_ID}-${DISK_ID}
```

snapshots:
```diff
-snapshot-${SNAP_ID}
+snap-${SNAP_ID}
```

Since linstor does not support resources rename (LINBIT/linstor-server#44) this change will bring only pain for the next update.

Do not merge.